### PR TITLE
Change the group id to reflect miqdigital OSS project

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
-    <groupId>com.mediaiq.caps.platform.scheduling</groupId>
+    <groupId>com.miqdigital.oss.scheduling</groupId>
     <artifactId>scheduling-service</artifactId>
     <version>1.12.0</version>
     <packaging>pom</packaging>

--- a/report/pom.xml
+++ b/report/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>scheduling-service</artifactId>
-        <groupId>com.mediaiq.caps.platform.scheduling</groupId>
+        <groupId>com.miqdigital.oss.scheduling</groupId>
         <version>1.12.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -12,12 +12,12 @@
     <artifactId>report</artifactId>
     <dependencies>
         <dependency>
-            <groupId>com.mediaiq.caps.platform.scheduling</groupId>
+            <groupId>com.miqdigital.oss.scheduling</groupId>
             <artifactId>scheduling-server</artifactId>
             <version>${parent.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.mediaiq.caps.platform.scheduling</groupId>
+            <groupId>com.miqdigital.oss.scheduling</groupId>
             <artifactId>scheduling-commons</artifactId>
             <version>${parent.version}</version>
         </dependency>

--- a/scheduling-client-sdk/pom.xml
+++ b/scheduling-client-sdk/pom.xml
@@ -7,7 +7,7 @@
 
     <parent>
         <artifactId>scheduling-service</artifactId>
-        <groupId>com.mediaiq.caps.platform.scheduling</groupId>
+        <groupId>com.miqdigital.oss.scheduling</groupId>
         <version>1.12.0</version>
     </parent>
 

--- a/scheduling-commons/pom.xml
+++ b/scheduling-commons/pom.xml
@@ -5,7 +5,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>scheduling-service</artifactId>
-        <groupId>com.mediaiq.caps.platform.scheduling</groupId>
+        <groupId>com.miqdigital.oss.scheduling</groupId>
         <version>1.12.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/scheduling-integration-test/pom.xml
+++ b/scheduling-integration-test/pom.xml
@@ -4,7 +4,7 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <parent>
         <artifactId>scheduling-service</artifactId>
-        <groupId>com.mediaiq.caps.platform.scheduling</groupId>
+        <groupId>com.miqdigital.oss.scheduling</groupId>
         <version>1.12.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
@@ -30,7 +30,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.mediaiq.caps.platform.scheduling</groupId>
+            <groupId>com.miqdigital.oss.scheduling</groupId>
             <artifactId>scheduling-commons</artifactId>
             <version>${project.parent.version}</version>
         </dependency>
@@ -40,7 +40,7 @@
             <version>${json-smart.version}</version>
         </dependency>
         <dependency>
-            <groupId>com.mediaiq.caps.platform.scheduling</groupId>
+            <groupId>com.miqdigital.oss.scheduling</groupId>
             <artifactId>scheduling-server</artifactId>
             <version>${project.parent.version}</version>
             <scope>test</scope>

--- a/scheduling-server/Dockerfile
+++ b/scheduling-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-alpine
+FROM eclipse-temurin:17-jdk-focal
 
 RUN apt-get --no-install-recommends update && apt-get --no-install-recommends install -y \
     curl \

--- a/scheduling-server/pom.xml
+++ b/scheduling-server/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <parent>
-        <groupId>com.mediaiq.caps.platform.scheduling</groupId>
+        <groupId>com.miqdigital.oss.scheduling</groupId>
         <artifactId>scheduling-service</artifactId>
         <version>1.12.0</version>
     </parent>
@@ -43,7 +43,7 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>com.mediaiq.caps.platform.scheduling</groupId>
+            <groupId>com.miqdigital.oss.scheduling</groupId>
             <artifactId>scheduling-commons</artifactId>
             <version>${project.parent.version}</version>
         </dependency>


### PR DESCRIPTION
Made changes to the groupId of the maven project to best reflect its usage
Changes in groupId
1. Renamed mediaiq to miqdigital, which is the correct name
2. Removed caps.platform
3. Added oss in the groupId name to avoid any future conflicts for same name for internal projects

partially closes #6 